### PR TITLE
Fix equal comparison

### DIFF
--- a/gb2260/division.py
+++ b/gb2260/division.py
@@ -37,7 +37,7 @@ class Division(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            raise NotImplemented
         return self.code == other.code and self.year == other.year
 
     @classmethod


### PR DESCRIPTION
Should be a typo? _(:3

By the way, I think in this situation, raise a TypeError may be more appropriate. For example:

```python
    def __eq__(self, other):
        if not isinstance(other, self.__class__):
            raise TypeError("%s is not a Division." % other)
        return self.code == other.code and self.year == other.year
```

Any ideas?