### PR TITLE
fix cache KeyError when garbage collected

### DIFF
--- a/gb2260/division.py
+++ b/gb2260/division.py
@@ -55,8 +55,11 @@ class Division(object):
         cache = cls._identity_map[year]
         store = data[year]
 
-        if key in cache:
+        try:
             return cache[key]
+        except KeyError:
+            pass
+
         if key in store:
             instance = cls(code, store[key], year)
             cache[key] = instance


### PR DESCRIPTION
WeakValueDictionary cache may get garbage collected, so the test "if key in cache" is not safe.
Let's test it on the fly.

Here is the exception happened to me:

  File "algo.py", line 64, in search
    if check_identity(id):
  File "algo.py", line 30, in check_identity
    division = gb2260.get(region)
  File "/opt/pypy3/site-packages/gb2260/division.py", line 59, in get
    return cache[key]
  File "/opt/pypy3/lib-python/3/weakref.py", line 159, in __getitem__
    raise KeyError(key)
KeyError: 621121